### PR TITLE
Misc build fixes from FreeBSD port

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <QLocale>
 #include <QString>
 
+#include <locale.h>
+
 #if defined(Q_OS_WIN)
 #include <windows.h>
 #endif

--- a/src/ui/keydialog.h
+++ b/src/ui/keydialog.h
@@ -15,7 +15,7 @@ public:
     explicit KeyDialog(QWidget *parent = 0);
     ~KeyDialog();
 
-    QPair<QString, QPair<QString, QString>> SelectKey(bool add, QPair<QString, QPair<QString, QString>> init = QPair<QString, QPair<QString, QString>>());
+    QPair<QString, QPair<QString, QString>> SelectKey(bool add, QPair<QString, QPair<QString, QString>> init = (QPair<QString, QPair<QString, QString>>()));
 
 protected:
     void SetButtons();

--- a/src/ui/preferencesdialog.h
+++ b/src/ui/preferencesdialog.h
@@ -27,7 +27,7 @@ protected:
     void AddRow(QString first, QString second, QString third);
     void ModifyRow(int row, QString first, QString second, QString third);
     void RemoveRow(int row);
-    void SelectKey(bool add, QPair<QString, QPair<QString, QString>> init = QPair<QString, QPair<QString, QString>>());
+    void SelectKey(bool add, QPair<QString, QPair<QString, QString>> init = (QPair<QString, QPair<QString, QString>>()));
 
 private:
     Ui::PreferencesDialog *ui;


### PR DESCRIPTION
[FreeBSD port](http://www.freshports.org/multimedia/baka-mplayer) uses GCC 4.8.4 by default on FreeBSD 8.x/9.x and Clang 3.3/3.4.1/3.5.1 with libc++ on FreeBSD 10.x/-CURRENT. DragonFly (via DPorts) also consumes the port [without](https://github.com/DragonFlyBSD/DeltaPorts/tree/master/ports/multimedia/baka-mplayer) additional patches. The status on non-x86 (e.g. arm or big-endian archs) is completely unknown to me. Build logs to glean *FLAGS used or warnings if any: [i386](http://beefy1.isc.freebsd.org/data/latest-per-pkg/baka-mplayer/), [amd64](http://beefy2.isc.freebsd.org/data/latest-per-pkg/baka-mplayer/)

The patches in this pull fix regressions in Baka-MPlayer v2.0.2. 4b1fd9f is optional given FreeBSD 10.0 with Clang 3.3 will be [EOL in 2015-02-28](https://www.freebsd.org/security/), later versions of Clang aren't affected.
