### PR TITLE
fix position of index for indexbutton

### DIFF
--- a/src/widgets/indexbutton.cpp
+++ b/src/widgets/indexbutton.cpp
@@ -38,9 +38,9 @@ void IndexButton::paintEvent(QPaintEvent *event)
         painter.setPen(QColor(0,0,0));
         painter.setFont(QFont("Noto Sans", 6));
         if(index > 0)   // next button
-            painter.drawText(region.adjusted(-2, -1, -2, -1), Qt::AlignCenter, QString::number(index));
+            painter.drawText(region.adjusted(-2, -1, -2, 0), Qt::AlignCenter, QString::number(index));
         else            // previous button
-            painter.drawText(region.adjusted(2, -1, 2, -1), Qt::AlignCenter, QString::number(-index));
+            painter.drawText(region.adjusted(2, -1, 2, 0), Qt::AlignCenter, QString::number(-index));
     }
 }
 


### PR DESCRIPTION
the index label of prev and next button should be move down 1px, isn't it?
before: 
![2015-10-18-03-49-09-12813](https://cloud.githubusercontent.com/assets/12208686/10560912/a8cb55a2-754b-11e5-86e7-5f51438acc14.png)
after:
![2015-10-18-03-47-14-19264](https://cloud.githubusercontent.com/assets/12208686/10560911/a8ca117e-754b-11e5-8f15-31bcc57312e3.png)
