### PR TITLE
libc++ buildfix

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1,6 +1,7 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
+#include <cmath>
 #include <QLibraryInfo>
 #include <QMimeData>
 #include <QDesktopWidget>
@@ -993,7 +994,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         ui->seekBar->setVisible(showPlayback || ui->outputTextEdit->isVisible());
 
         QRect playlistRect = geometry();
-        playlistRect.setLeft(playlistRect.right() - ceil(playlistRect.width()/7.0));
+        playlistRect.setLeft(playlistRect.right() - std::ceil(playlistRect.width()/7.0));
         bool showPlaylist = playlistRect.contains(event->globalPos());
         ShowPlaylist(showPlaylist);
 


### PR DESCRIPTION
Building baka-mplayer with libc++ (on FreeBSD, OS X) fails with

```c++
src/ui/mainwindow.cpp:996:53: error: use of undeclared identifier 'ceil'
        playlistRect.setLeft(playlistRect.right() - ceil(playlistRect.width()/7.0));
                                                    ^
1 error generated.
```

Compare with libstdc++ bootlegging `ceil()` declaration as follows

```c++
In file included from /usr/include/math.h:254:0,
                 from /usr/local/lib/gcc5/include/c++/cmath:44:0,
                 from /usr/local/lib/gcc5/include/c++/random:38,
                 from /usr/local/lib/gcc5/include/c++/bits/stl_algo.h:66,
                 from /usr/local/lib/gcc5/include/c++/algorithm:62,
                 from /usr/local/include/qt5/QtCore/qglobal.h:81,
                 from /usr/local/include/qt5/QtGui/qwindowdefs.h:37,
                 from /usr/local/include/qt5/QtWidgets/qwidget.h:37,
                 from /usr/local/include/qt5/QtWidgets/qmainwindow.h:37,
                 from /usr/local/include/qt5/QtWidgets/QMainWindow:1,
                 from src/ui/mainwindow.h:4,
                 from src/ui/mainwindow.cpp:1:
```
(discovered by putting `#error` in math.h)