### PR TITLE
Fixes accepted customlabel:mousePressEvent from propagating to MainWindow

### DIFF
--- a/src/widgets/customlabel.cpp
+++ b/src/widgets/customlabel.cpp
@@ -12,5 +12,7 @@ void CustomLabel::mousePressEvent(QMouseEvent *event)
         emit clicked();
         event->accept();
     }
-    QLabel::mousePressEvent(event);
+    else {
+        QLabel::mousePressEvent(event);
+    }
 }


### PR DESCRIPTION
The left mouse click event (to open the playlist index dialog) was propagating to the main window. This caused a mouse gesture to start, making the main window move with the mouse until clicking, ending the gesture.