### PR TITLE
Fix audio icon

### DIFF
--- a/src/mpvhandler.cpp
+++ b/src/mpvhandler.cpp
@@ -32,6 +32,7 @@ MpvHandler::MpvHandler(int64_t wid, QObject *parent):
     mpv_set_option_string(mpv, "cursor-autohide", "no");// no cursor-autohide, we handle that
     mpv_set_option_string(mpv, "ytdl", "yes"); // youtube-dl support
     mpv_set_option_string(mpv, "sub-auto", "fuzzy"); // Automatic subfile detection
+    mpv_set_option_string(mpv, "audio-client-name", "baka-mplayer"); // show correct icon in e.g. pavucontrol
 
     // get updates when these properties change
     mpv_observe_property(mpv, 0, "playback-time", MPV_FORMAT_DOUBLE);


### PR DESCRIPTION
Allow applications like pavucontrol show a correct icon of the PulseAudio consumer.

Fixes: https://github.com/u8sand/Baka-MPlayer/issues/320

Before:
![image](https://user-images.githubusercontent.com/15802528/175294401-b393502f-9586-4971-8644-3be9f4a1873d.png)
After:
![2022-06-23_15-00](https://user-images.githubusercontent.com/15802528/175294414-4b9e8f23-11f2-4bc9-a39b-c29d5aa3f341.png)
